### PR TITLE
Fix flight state transitions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ val modversion = property("mod.version") as String
 val mcversion = property("minecraft_version") as String
 val versionrange = property("minecraft_version_range") as String
 val loaderversion = property("loader_version") as String
-val oneconfigVersion = "1.0.1"
+val oneconfigVersion = "1.0.14"
 
 base {
     archivesName.set("$modid-$modversion+$mcversion")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/org/polyfrost/polysprint/mixins/Mixin_SetFlyBoost.java
+++ b/src/main/java/org/polyfrost/polysprint/mixins/Mixin_SetFlyBoost.java
@@ -22,7 +22,7 @@ import com.mojang.authlib.GameProfile;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.player.AbstractClientPlayer;
 //? if =1.21.1
-/*import net.minecraft.client.player.Input;*/
+//import net.minecraft.client.player.Input;
 //? if >1.21.1
 import net.minecraft.client.player.ClientInput;
 import net.minecraft.client.player.LocalPlayer;
@@ -37,7 +37,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(LocalPlayer.class)
 public abstract class Mixin_SetFlyBoost extends AbstractClientPlayer {
     //? if =1.21.1
-    /*@Shadow public Input input;*/
+    //@Shadow public Input input;
     //? if >1.21.1
     @Shadow public ClientInput input;
 

--- a/src/main/java/org/polyfrost/polysprint/mixins/event/Mixin_FlyEvent.java
+++ b/src/main/java/org/polyfrost/polysprint/mixins/event/Mixin_FlyEvent.java
@@ -33,7 +33,10 @@ import org.spongepowered.asm.mixin.injection.At;
 public abstract class Mixin_FlyEvent {
     @WrapOperation(method = "handlePlayerAbilities", at = @At(value = "FIELD", target = "Lnet/minecraft/world/entity/player/Abilities;flying:Z", opcode = Opcodes.PUTFIELD))
     private void onSetFlying(Abilities instance, boolean state, Operation<Void> original) {
-        instance.flying = state;
+        boolean changed = instance.flying != state;
+        original.call(instance, state);
+        if (!changed) return;
+
         Event event;
         if (state) {
             event = new SprintStateEvent.Start(SprintStateEvent.Type.FLY);

--- a/src/main/java/org/polyfrost/polysprint/mixins/event/Mixin_FlyEvent_2EletricBoogaloo.java
+++ b/src/main/java/org/polyfrost/polysprint/mixins/event/Mixin_FlyEvent_2EletricBoogaloo.java
@@ -33,7 +33,10 @@ import org.spongepowered.asm.mixin.injection.At;
 public abstract class Mixin_FlyEvent_2EletricBoogaloo {
     @WrapOperation(method = "updatePlayerAbilities", at = @At(value = "FIELD", target = "Lnet/minecraft/world/entity/player/Abilities;flying:Z", opcode = Opcodes.PUTFIELD))
     private void onSetFlying(Abilities instance, boolean state, Operation<Void> original) {
-        instance.flying = state;
+        boolean changed = instance.flying != state;
+        original.call(instance, state);
+        if (!changed) return;
+
         Event event;
         if (state) {
             event = new SprintStateEvent.Start(SprintStateEvent.Type.FLY);

--- a/src/main/java/org/polyfrost/polysprint/mixins/event/Mixin_FlyEvent_NumeroTres.java
+++ b/src/main/java/org/polyfrost/polysprint/mixins/event/Mixin_FlyEvent_NumeroTres.java
@@ -33,7 +33,10 @@ import org.spongepowered.asm.mixin.injection.At;
 public class Mixin_FlyEvent_NumeroTres {
     @WrapOperation(method = "aiStep", at = @At(value = "FIELD", target = "Lnet/minecraft/world/entity/player/Abilities;flying:Z", opcode = Opcodes.PUTFIELD))
     private void onSetFlying(Abilities instance, boolean state, Operation<Void> original) {
-        instance.flying = state;
+        boolean changed = instance.flying != state;
+        original.call(instance, state);
+        if (!changed) return;
+
         Event event;
         if (state) {
             event = new SprintStateEvent.Start(SprintStateEvent.Type.FLY);

--- a/src/main/kotlin/org/polyfrost/polysprint/client/PolySprintClient.kt
+++ b/src/main/kotlin/org/polyfrost/polysprint/client/PolySprintClient.kt
@@ -134,13 +134,13 @@ object PolySprintClient {
         return when (key.type) {
             InputConstants.Type.KEYSYM, InputConstants.Type.SCANCODE ->
                 //? if <1.21.10
-                /*InputConstants.isKeyDown(Minecraft.getInstance().window.window, key.value)*/
+                //InputConstants.isKeyDown(Minecraft.getInstance().window.window, key.value)
                 //? if >=1.21.10
                 InputConstants.isKeyDown(Minecraft.getInstance().window, key.value)
 
             InputConstants.Type.MOUSE ->
                 //? if <1.21.10
-                /*GLFW.glfwGetMouseButton(Minecraft.getInstance().window.window, key.value) == GLFW.GLFW_PRESS*/
+                //GLFW.glfwGetMouseButton(Minecraft.getInstance().window.window, key.value) == GLFW.GLFW_PRESS
                 //? if >=1.21.10
                 GLFW.glfwGetMouseButton(Minecraft.getInstance().window.handle(), key.value) == GLFW.GLFW_PRESS
 

--- a/src/main/kotlin/org/polyfrost/polysprint/client/PolySprintClient.kt
+++ b/src/main/kotlin/org/polyfrost/polysprint/client/PolySprintClient.kt
@@ -54,10 +54,20 @@ object PolySprintClient {
             processInput()
         }.register()
 
-        eventHandler { event: SprintStateEvent.End ->
-            if (event.type == SprintStateEvent.Type.FLY && PolySprintConfig.toggleFlyBoost) {
-                PolySprintConfig.resyncSprintKeyState()
+        eventHandler { event: SprintStateEvent.Start ->
+            if (event.type != SprintStateEvent.Type.FLY || lastFlying) return@eventHandler
+
+            lastFlying = true
+            if (PolySprintConfig.isEnabled && PolySprintConfig.toggleSneakState && PolySprintConfig.unsneakOnFlightStart) {
+                PolySprintConfig.invertToggleSneakState()
             }
+        }.register()
+
+        eventHandler { event: SprintStateEvent.End ->
+            if (event.type != SprintStateEvent.Type.FLY) return@eventHandler
+
+            lastFlying = false
+            if (PolySprintConfig.toggleFlyBoost) PolySprintConfig.resyncSprintKeyState()
         }.register()
 
         CommandManager.register(CommandManager.literal(PolySprintConstants.ID).executes {
@@ -94,7 +104,7 @@ object PolySprintClient {
         val flying = Minecraft.getInstance().player?.abilities?.flying == true
 
         if (lastFlying != flying) {
-            if (PolySprintConfig.toggleSneakState && PolySprintConfig.unsneakOnFlightStart)
+            if (flying && PolySprintConfig.toggleSneakState && PolySprintConfig.unsneakOnFlightStart)
                 PolySprintConfig.invertToggleSneakState()
 
             lastFlying = flying


### PR DESCRIPTION
## Description

chore: cleanup and update (1d21b28e880e216de827f1fdecf635ccc8e3ec19)
- Update oneconfig to 1.0.14 and gradle to 9.6.1
- Clean wrong stonecutter comments

fix: flight togglesneak transition (983b5b93a753c0080e4d118c5a51e4684e9648f8)
- Unsneak immediately when flight starts instead of waiting for another input event
- Previously with the unsneak on flight start option enabled, trying to start flying when toggle sneak was enabled caused a ~1 second delay before when it actually unsneaked

fix: handle flight state transitions correctly (0831e96438f7fcedb4a5c78004b9a0e7663a6a6c)
- Emit flight events only when the flying state actually changes. Most events were previously emitted twice
- Call `original.call` inside the `@WrapOperation`

I didnt update the version

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Fixed unseak on flight start not unsneaking immediately
Fixed duplicate flight state events
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->